### PR TITLE
Indexing createDate and updateDate as date fields by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Umbraco's "path" field is automatically indexed as a list and so a content item 
 query.Field("path", "1100");
 ```
 
+By default Umbraco indexes the `createDate` and `updateDate` fields as strings. This package overwrites the index to change it as long.
+
 ## Contribution guidelines
 
 To raise a new bug, create an issue on the GitHub repository. To fix a bug or add new features, fork the repository and send a pull request with your changes. Feel free to add ideas to the repository's issues list if you would to discuss anything related to the library.

--- a/src/Our.Umbraco.Extensions.Search/Startup/IndexComponent.cs
+++ b/src/Our.Umbraco.Extensions.Search/Startup/IndexComponent.cs
@@ -35,6 +35,10 @@ namespace Our.Umbraco.Extensions.Search.Startup
                 valueTypeFactories.AddOrUpdate("udi", new DelegateFieldValueTypeFactory(x => new UdiValueType(x)));
 
                 fieldDefinitions.AddOrUpdate(new FieldDefinition("path", "list"));
+
+                fieldDefinitions.AddOrUpdate(new FieldDefinition("createDate", "date"));
+
+                fieldDefinitions.AddOrUpdate(new FieldDefinition("updateDate", "date"));
             }
         }
 


### PR DESCRIPTION
createDate and updateDate fields are indexed as strings by default in Umbraco. This fact prevented us to perform sorting on these fields. The PR is for changing the index type to date so it would allow sorting when needed.